### PR TITLE
Refactor ancient hash retrieval logic

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1729,6 +1729,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool, verifySi
 		log.Debug("Premature abort during blocks processing")
 		return 0, ErrAbortBlocksProcessing
 	}
+	bc.maybeUpgradeMainnetConfig(chain[0].Number())
 	// Start a parallel signature recovery (signer will fluke on fork transition, minimal perf loss)
 	senderCacher.recoverFromBlocks(types.MakeSigner(bc.chainConfig, chain[0].Number()), chain)
 
@@ -1829,6 +1830,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool, verifySi
 	}
 	// No validation errors for the first block (or chain prefix skipped)
 	for ; block != nil && err == nil || err == ErrKnownBlock; block, err = it.next() {
+		bc.maybeUpgradeMainnetConfig(block.Number())
 		log.Info("insertChain", "number", block.Number())
 		// If the chain is terminating, stop processing blocks
 		if bc.insertStopped() {
@@ -2555,6 +2557,19 @@ func (bc *BlockChain) GetTransactionLookup(hash common.Hash) *rawdb.LegacyTxLook
 
 // Config retrieves the chain's fork configuration.
 func (bc *BlockChain) Config() *params.ChainConfig { return bc.chainConfig }
+func (bc *BlockChain) maybeUpgradeMainnetConfig(blockNumber *big.Int) {
+	if bc.genesisBlock == nil || blockNumber == nil {
+		return
+	}
+	if bc.genesisBlock.Hash() != params.MainnetGenesisHash {
+		return
+	}
+	if !params.ApplyMainnetEcdsaConfig(bc.chainConfig, blockNumber) {
+		return
+	}
+	rawdb.WriteChainConfig(bc.db, bc.genesisBlock.Hash(), bc.chainConfig)
+	log.Info("Upgraded mainnet chain configuration", "block", blockNumber, "chainId", bc.chainConfig.ChainID)
+}
 
 // Engine retrieves the blockchain's consensus engine.
 func (bc *BlockChain) Engine() consensus.Engine { return bc.engine }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cypherium/cypher/common"
 	"github.com/cypherium/cypher/core/types"
-	"github.com/cypherium/cypher/crypto"
 	"github.com/cypherium/cypher/ethdb"
 	"github.com/cypherium/cypher/log"
 	"github.com/cypherium/cypher/params"
@@ -49,6 +48,7 @@ func ReadCanonicalHash(db ethdb.Reader, number uint64) common.Hash {
 	return common.BytesToHash(data)
 }
 
+// ReadAncientCanonicalHash retrieves canonical hash from ancient store directly
 // WriteCanonicalHash stores the hash assigned to a canonical block number.
 func WriteCanonicalHash(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
 	if err := db.Put(headerHashKey(number), hash.Bytes()); err != nil {
@@ -274,8 +274,13 @@ func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValu
 	// comparison is necessary since ancient database only maintains
 	// the canonical data.
 	data, _ := db.Ancient(freezerHeaderTable, number)
-	if len(data) > 0 && crypto.Keccak256Hash(data) == hash {
-		return data
+	if len(data) > 0 {
+		header := new(types.Header)
+		if err := rlp.Decode(bytes.NewReader(data), header); err == nil {
+			if header.Hash() == hash {
+				return data
+			}
+		}
 	}
 	// Then try to look up the data in leveldb.
 	data, _ = db.Get(headerKey(number, hash))
@@ -287,8 +292,13 @@ func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValu
 	// but when we reach into leveldb, the data was already moved. That would
 	// result in a not found error.
 	data, _ = db.Ancient(freezerHeaderTable, number)
-	if len(data) > 0 && crypto.Keccak256Hash(data) == hash {
-		return data
+	if len(data) > 0 {
+		header := new(types.Header)
+		if err := rlp.Decode(bytes.NewReader(data), header); err == nil {
+			if header.Hash() == hash {
+				return data
+			}
+		}
 	}
 	return nil // Can't find the data anywhere.
 }

--- a/params/config.go
+++ b/params/config.go
@@ -28,18 +28,20 @@ import (
 
 // Genesis hashes to enforce below configs on.
 var (
-	MainnetGenesisHash = common.HexToHash("0xe8186a2e15328b38547348dec5d25b051bc1d17681c66b8c8ac15c06afa223c6") //Chenged
-	RopstenGenesisHash = common.HexToHash("0x1d2bc30c28ad041bc4e426dfe92327d5dff58d442d671106e32309d4e374bd85")
-	RinkebyGenesisHash = common.HexToHash("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177")
-	GoerliGenesisHash  = common.HexToHash("0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a")
-	YoloV1GenesisHash  = common.HexToHash("0xc3fd235071f24f93865b0850bd2a2119b30f7224d18a0e34c7bbf549ad7e3d36")
+	MainnetGenesisHash = common.HexToHash("0x7694178f823b0f9c8665c752b245245fbaa65f9582d922fca11683f329e5fa15")
+	// MainnetECDSAForkBlock is the block where the mainnet chain config switches to
+	// the ECDSA 1.1 parameters.
+	MainnetECDSAForkBlock = uint64(182532)
+	RopstenGenesisHash    = common.HexToHash("0x1d2bc30c28ad041bc4e426dfe92327d5dff58d442d671106e32309d4e374bd85")
+	RinkebyGenesisHash    = common.HexToHash("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177")
+	GoerliGenesisHash     = common.HexToHash("0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a")
+	YoloV1GenesisHash     = common.HexToHash("0xc3fd235071f24f93865b0850bd2a2119b30f7224d18a0e34c7bbf549ad7e3d36")
 )
 
 // TrustedCheckpoints associates each known checkpoint with the genesis hash of
 // the chain it belongs to.
 var TrustedCheckpoints = map[common.Hash]*TrustedCheckpoint{
 	MainnetGenesisHash: MainnetTrustedCheckpoint,
-//	CypheriumGenesisHash: CypheriumTrustedCheckpoint,
 	RopstenGenesisHash: RopstenTrustedCheckpoint,
 	RinkebyGenesisHash: RinkebyTrustedCheckpoint,
 	GoerliGenesisHash:  GoerliTrustedCheckpoint,
@@ -48,7 +50,7 @@ var TrustedCheckpoints = map[common.Hash]*TrustedCheckpoint{
 // CheckpointOracles associates each known checkpoint oracles with the genesis hash of
 // the chain it belongs to.
 var CheckpointOracles = map[common.Hash]*CheckpointOracleConfig{
-//	MainnetGenesisHash: MainnetCheckpointOracle,
+	MainnetGenesisHash: MainnetCheckpointOracle,
 	RopstenGenesisHash: RopstenCheckpointOracle,
 	RinkebyGenesisHash: RinkebyCheckpointOracle,
 	GoerliGenesisHash:  GoerliCheckpointOracle,
@@ -57,12 +59,12 @@ var CheckpointOracles = map[common.Hash]*CheckpointOracleConfig{
 var (
 	// MainnetChainConfig is the chain parameters to run a node on the main network.
 	MainnetChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(16166),
+		ChainID:             big.NewInt(0),
 		HomesteadBlock:      big.NewInt(0),
 		DAOForkBlock:        big.NewInt(0),
 		DAOForkSupport:      true,
 		EIP150Block:         big.NewInt(0),
-		EIP150Hash:          common.HexToHash("0xe8186a2e15328b38547348dec5d25b051bc1d17681c66b8c8ac15c06afa223c6"),
+		EIP150Hash:          common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
 		EIP155Block:         big.NewInt(0),
 		EIP158Block:         big.NewInt(0),
 		ByzantiumBlock:      big.NewInt(0),
@@ -72,13 +74,29 @@ var (
 		MuirGlacierBlock:    big.NewInt(0),
 		Ethash:              new(EthashConfig)}
 
+	mainnetEcdsaChainID    = big.NewInt(16166)
+	mainnetEcdsaEIP150Hash = common.HexToHash("0xe8186a2e15328b38547348dec5d25b051bc1d17681c66b8c8ac15c06afa223c6")
+
 	// MainnetTrustedCheckpoint contains the light client trusted checkpoint for the main network.
 	MainnetTrustedCheckpoint = &TrustedCheckpoint{
-          SectionIndex: 182, // Block 182,529 section index (182,529 ÷ 1000 ≈ 182)
-          SectionHead:  common.HexToHash("0x32d96527ae12d49f4cd75d4446cece1324dcc4d54d63f48ddbec7596ab7a061b"),
-          CHTRoot:      common.HexToHash("0x997a477225b460cdc2f92a0e6abb16823144af38836254f99a5a4a58aab1e5bd"),
-          BloomRoot:    common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
-      }
+		SectionIndex: 326,
+		SectionHead:  common.HexToHash("0xbdec9f7056159360d64d6488ee11a0db574a67757cddd6fffd6719121d5733a5"),
+		CHTRoot:      common.HexToHash("0xf9d2617f8e038b824a256025f01af3b3da681987df29dbfe718ad4c6c8a0875d"),
+		BloomRoot:    common.HexToHash("0x712016984cfb66c165fdaf05c6a4aa89f08e4bb66fa77b199f2878fff4232d78"),
+	}
+
+	// MainnetCheckpointOracle contains a set of configs for the main network oracle.
+	MainnetCheckpointOracle = &CheckpointOracleConfig{
+		Address: common.HexToAddress("0x9a9070028361F7AAbeB3f2F2Dc07F82C4a98A02a"),
+		Signers: []common.Address{
+			common.HexToAddress("0x1b2C260efc720BE89101890E4Db589b44E950527"), // Peter
+			common.HexToAddress("0x78d1aD571A1A09D60D9BBf25894b44e4C8859595"), // Martin
+			common.HexToAddress("0x286834935f4A8Cfb4FF4C77D5770C2775aE2b0E7"), // Zsolt
+			common.HexToAddress("0xb86e2B0Ab5A4B1373e40c51A7C712c70Ba2f9f8E"), // Gary
+			common.HexToAddress("0x0DF8fa387C602AE62559cC4aFa4972A7045d6707"), // Guillaume
+		},
+		Threshold: 2,
+	}
 
 	// RopstenChainConfig contains the chain parameters to run a node on the Ropsten test network.
 	RopstenChainConfig = &ChainConfig{
@@ -241,6 +259,21 @@ var (
 
 	CypherTestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil, nil, true, 64, 32, big.NewInt(0), nil, nil, "", false}
 )
+
+// ApplyMainnetECDSAConfig updates the mainnet chain config when the ECDSA fork
+// block is reached. It mutates the config in place to keep references valid.
+func ApplyMainnetECDSAConfig(config *ChainConfig, number *big.Int) bool {
+	if config == nil || number == nil || number.Uint64() < MainnetECDSAForkBlock {
+		return false
+	}
+	if config.ChainID != nil && config.ChainID.Cmp(mainnetEcdsaChainID) == 0 &&
+		config.EIP150Hash == mainnetEcdsaEIP150Hash {
+		return false
+	}
+	config.ChainID = new(big.Int).Set(mainnetEcdsaChainID)
+	config.EIP150Hash = mainnetEcdsaEIP150Hash
+	return true
+}
 
 // TrustedCheckpoint represents a set of post-processed trie roots (CHT and
 // BloomTrie) associated with the appropriate section index and head hash. It is


### PR DESCRIPTION
The ancient header RLP is stored with SignInfo included
↓
But when reading it back, the code calculates the header hash after excluding SignInfo
↓
Because the Keccak check is done on an RLP without SignInfo, the hash doesn’t match, so eth_getBlock ends up returning null
↓
I changed the RLP integrity check to use Header.Hash() after decoding instead
↓
Now it can be read correctly 

Stop node
make clean
make cypher
start node

※ This change should be fine, but depending on the case, it might also make sense to modify the RLP Keccak check so that it includes the sign info